### PR TITLE
remove need for explicitly adding the Current term

### DIFF
--- a/australia/Rakefile.rb
+++ b/australia/Rakefile.rb
@@ -20,5 +20,5 @@ task :connect_chambers => :ensure_legislature_exists do
   end
 end
 
-task :process_json => [:connect_chambers, :default_memberships_to_current_term]
+file 'final.json' => :connect_chambers
 

--- a/canada/Rakefile.rb
+++ b/canada/Rakefile.rb
@@ -9,4 +9,3 @@ require_relative '../rakefile_morph.rb'
   start_date: "2011-06-02",
 }
 
-task :process_json => :default_memberships_to_current_term

--- a/denmark/Rakefile.rb
+++ b/denmark/Rakefile.rb
@@ -38,12 +38,12 @@ task :add_party_names => :load_json do
   end
 end
 
-task :process_json => [
+task 'final.json' => [
   :dk_remove_not_current,
   :clean_orphaned_memberships,
   :add_party_names,
-  :ensure_legislative_period,
-  :switch_party_to_behalf,
-  :default_memberships_to_current_term,
 ] 
+
+# Don't add term until the membership exists!
+task :ensure_memberships_have_term => :switch_party_to_behalf
 

--- a/iran/Rakefile.rb
+++ b/iran/Rakefile.rb
@@ -9,4 +9,3 @@ require_relative '../rakefile_popit.rb'
   start_date: "2012-05-27",
 }
 
-task :process_json => :default_memberships_to_current_term

--- a/italy/Rakefile.rb
+++ b/italy/Rakefile.rb
@@ -9,4 +9,3 @@ require_relative '../rakefile_popit.rb'
   start_date: '2013-03-15'
 }
 
-task :process_json => :default_memberships_to_current_term

--- a/wales/Rakefile.rb
+++ b/wales/Rakefile.rb
@@ -8,4 +8,3 @@ require_relative '../rakefile_popit.rb'
   start_date: '2011-09-15',
 }
 
-task :process_json => :default_memberships_to_current_term


### PR DESCRIPTION
Have a task that makes sure there’s at least one Term, and default it
to what’s in `@current_term`, so that each Rakefile doesn’t need to
specify that dependency directly.