### PR TITLE
Rakefile publish promit

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -41,7 +41,7 @@ task :publish do
     %x[ hub add data ]
     %x[ hub commit -m "Refresh with new data from #{last_commit}" ]
     %x[ hub push -u origin #{branch_name} ]
-    %x[ hub pull-request -m "Refresh with new data from #{last_commit}" ]
+    %x[ hub pull-request ]
   end
 end
 


### PR DESCRIPTION
Rather than auto generating a fairly meaningless Pull Request message,
prompt for what that should be.

If we ever automate this step, we’ll need to add the message back.